### PR TITLE
Correct anchor not wrapping resume button

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -20,7 +20,7 @@
 			<div id="landingContent">
 				<h1>ani srikanth</h1>
 				<p>// portfolio 2020 //</p>
-				<a href="https://drive.google.com/open?id=1xFMzh4TMwRt8aA31bT6K014g42u12JAi"><button>RESUME</button></a>
+				<a href="https://drive.google.com/open?id=1xFMzh4TMwRt8aA31bT6K014g42u12JAi">RESUME</a>
 			</div>
 		</div>
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -43,18 +43,23 @@ body {
     text-align: center;
 }
 
-#landing button {
+#landing a {
+    text-align: center;
+    font-family: 'Karla', sans-serif;
+    display: inline-block;
     background-color: #0b0b0b;
     width: 200px;
     height: 44px;
     color: white;
     border: 1px solid;
     border-radius: 44px;
-    margin-left:calc((100% - 200px)/2);
+    margin-left: calc((100% - 200px)/2);
+    text-decoration: none;
+    line-height: 44px;
     transition: 0.25s;
 }
 
-#landing button:hover{
+#landing a:hover{
     background-color: orange;
 }
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -46,6 +46,7 @@ body {
 #landing a {
     text-align: center;
     font-family: 'Karla', sans-serif;
+    font-size: 14px;
     display: inline-block;
     background-color: #0b0b0b;
     width: 200px;


### PR DESCRIPTION
There was a problem where the link for the resume button was much wider than the button, failing to wrap only the desired clickable area.

![image](https://user-images.githubusercontent.com/14436239/84197979-d54eed00-aa70-11ea-90fc-9c77cd1d8f7d.png)

As can be seen in the below photo, the cursor doesn't switch to the clickable cursor to the left of the button anymore

![Screen Shot 2020-06-09 at 4 49 51 PM](https://user-images.githubusercontent.com/14436239/84198367-6d4cd680-aa71-11ea-9015-83396f47a7d7.png)
